### PR TITLE
How to raindance updates

### DIFF
--- a/guides/03-how-to-raindance.md
+++ b/guides/03-how-to-raindance.md
@@ -4,15 +4,15 @@ This guide will walk you through the process.
 
 ## raindance
 
-![Raindance Channel](../images/raindance/rain1.jpg)
+![Raindance Channel](images/raindance/rain1.jpg)
 
-A raindance can happen when the TurtleBotRain wallet has acumulated 10,000 turtles.
+A raindance can happen when the TurtleBotRain wallet has accumulated 5,000 or more TRTL. It can also be triggered at-will by an admin.
 
-![Forecast](../images/raindance/forecast.jpg)
+![Forecast](images/raindance/forecast.jpg)
 
-When TurtleBotRain posts in the raindance channel it means a Raindance is about to begin!
+When TurtleBotRain posts in the #raindance channel it means a Raindance is about to begin!
 
-![A Raindance is about to begin](../images/raindance/tuttut.jpg)
+![A Raindance is about to begin](images/raindance/tuttut.jpg)
 
 When you see this message the RainDance will begin soon.
 Get your TRTL wallet address ready.
@@ -21,33 +21,34 @@ Get your TRTL wallet address ready.
 
 Wait for the “Quick, send me your wallet” message.
 
-![Quick, send your wallet!](../images/raindance/quick_rain.jpg)
+![Quick, send your wallet!](images/raindance/quick_rain.jpg)
 
-Click on TurtleBotRain to send your address as a PM to TurtleBotRain.
+Click on TurtleBotRain to send your address in a private message to TurtleBotRain.
 
-![Click on this](../images/raindance/turtlebotrain.jpg)
+![Click on this](images/raindance/turtlebotrain.jpg)
 
-![DM the bot](../images/raindance/pm_bot.jpg)
+![DM the bot](images/raindance/pm_bot.jpg)
 
-You should recieve a PM back that looks like something like this:
+You should receive a private message back that looks like something like this:
 
-![You get a response](../images/raindance/respo1.jpg)
+![You get a response](images/raindance/respo1.jpg)
 
 or
 
-![You get a different resopnse](../images/raindance/respo2.jpg)
+![You get a different resopnse](images/raindance/respo2.jpg)
 
-**The Emoji will be different for everyone**
+**The emoji will be different for everyone**
 
-Now return to the raindance channel and react with the emoji you recieved in the PM.
+Now return to the #raindance channel and react with the emoji you received in the private message.
 
-![React](../images/raindance/react.jpg)
+![React](images/raindance/react.jpg)
 
-Only click the emoji listed in the PM.
+Only click the emoji listed in the private message.
 
-If you did everything correct you are included in the payout! Congrats!
+If you did everything correctly you will be included in the payout! Congrats!
+TurtleBotRain will reply with the amount that you'll receive.
 
-![Payout!](../images/raindance/payout.jpg)
+![Payout!](images/raindance/payout.jpg)
 
 
 
@@ -56,7 +57,7 @@ If you did everything correct you are included in the payout! Congrats!
 
 ## !rain
 
-![Forecast](../images/raindance/forecast.jpg)
+![Forecast](images/raindance/forecast.jpg)
 
 If you type !rain **in the bots channel only** you should get a response back with how many turtles are needed for a raindance.
 
@@ -64,34 +65,34 @@ If you type !rain **in the bots channel only** you should get a response back wi
 ## Notify
 
 
-![Notification](../images/raindance/notify.jpg)
+![Notification](images/raindance/notify.jpg)
 
 
 Enabling notifications for the raindance channel is easy.
 
 Click the dropdown arrow.
 
-![Dropdown](../images/raindance/notify1.jpg)
+![Dropdown](images/raindance/notify1.jpg)
 
 Click on notification settings.
 
-![Notification Settings](../images/raindance/notify2.jpg)
+![Notification Settings](images/raindance/notify2.jpg)
 
 Scroll down.
 
-![Scroll on down](../images/raindance/notify3.jpg)
+![Scroll on down](images/raindance/notify3.jpg)
 
 Look for notification overrides.
 
-![Notifcation Overrides](../images/raindance/notify4.jpg)
+![Notifcation Overrides](images/raindance/notify4.jpg)
 
 Select "raindance".
 
-![Select Raindance](../images/raindance/notify5.jpg)
+![Select Raindance](images/raindance/notify5.jpg)
 
 Select "All".
 
-![Select All](../images/raindance/notify6.jpg)
+![Select All](images/raindance/notify6.jpg)
 
 Done.
 

--- a/guides/03-how-to-raindance.md
+++ b/guides/03-how-to-raindance.md
@@ -4,15 +4,15 @@ This guide will walk you through the process.
 
 ## raindance
 
-![Raindance Channel](images/raindance/rain1.jpg)
+![Raindance Channel](../images/raindance/rain1.jpg)
 
 A raindance can happen when the TurtleBotRain wallet has accumulated 5,000 or more TRTL. It can also be triggered at-will by an admin.
 
-![Forecast](images/raindance/forecast.jpg)
+![Forecast](../images/raindance/forecast.jpg)
 
 When TurtleBotRain posts in the #raindance channel it means a Raindance is about to begin!
 
-![A Raindance is about to begin](images/raindance/tuttut.jpg)
+![A Raindance is about to begin](../images/raindance/tuttut.jpg)
 
 When you see this message the RainDance will begin soon.
 Get your TRTL wallet address ready.
@@ -21,34 +21,34 @@ Get your TRTL wallet address ready.
 
 Wait for the “Quick, send me your wallet” message.
 
-![Quick, send your wallet!](images/raindance/quick_rain.jpg)
+![Quick, send your wallet!](../images/raindance/quick_rain.jpg)
 
 Click on TurtleBotRain to send your address in a private message to TurtleBotRain.
 
-![Click on this](images/raindance/turtlebotrain.jpg)
+![Click on this](../images/raindance/turtlebotrain.jpg)
 
-![DM the bot](images/raindance/pm_bot.jpg)
+![DM the bot](../images/raindance/pm_bot.jpg)
 
 You should receive a private message back that looks like something like this:
 
-![You get a response](images/raindance/respo1.jpg)
+![You get a response](../images/raindance/respo1.jpg)
 
 or
 
-![You get a different resopnse](images/raindance/respo2.jpg)
+![You get a different resopnse](../images/raindance/respo2.jpg)
 
 **The emoji will be different for everyone**
 
 Now return to the #raindance channel and react with the emoji you received in the private message.
 
-![React](images/raindance/react.jpg)
+![React](../images/raindance/react.jpg)
 
 Only click the emoji listed in the private message.
 
 If you did everything correctly you will be included in the payout! Congrats!
 TurtleBotRain will reply with the amount that you'll receive.
 
-![Payout!](images/raindance/payout.jpg)
+![Payout!](../images/raindance/payout.jpg)
 
 
 
@@ -57,7 +57,7 @@ TurtleBotRain will reply with the amount that you'll receive.
 
 ## !rain
 
-![Forecast](images/raindance/forecast.jpg)
+![Forecast](../images/raindance/forecast.jpg)
 
 If you type !rain **in the bots channel only** you should get a response back with how many turtles are needed for a raindance.
 
@@ -65,34 +65,34 @@ If you type !rain **in the bots channel only** you should get a response back wi
 ## Notify
 
 
-![Notification](images/raindance/notify.jpg)
+![Notification](../images/raindance/notify.jpg)
 
 
 Enabling notifications for the raindance channel is easy.
 
 Click the dropdown arrow.
 
-![Dropdown](images/raindance/notify1.jpg)
+![Dropdown](../images/raindance/notify1.jpg)
 
 Click on notification settings.
 
-![Notification Settings](images/raindance/notify2.jpg)
+![Notification Settings](../images/raindance/notify2.jpg)
 
 Scroll down.
 
-![Scroll on down](images/raindance/notify3.jpg)
+![Scroll on down](../images/raindance/notify3.jpg)
 
 Look for notification overrides.
 
-![Notifcation Overrides](images/raindance/notify4.jpg)
+![Notifcation Overrides](../images/raindance/notify4.jpg)
 
 Select "raindance".
 
-![Select Raindance](images/raindance/notify5.jpg)
+![Select Raindance](../images/raindance/notify5.jpg)
 
 Select "All".
 
-![Select All](images/raindance/notify6.jpg)
+![Select All](../images/raindance/notify6.jpg)
 
 Done.
 

--- a/guides/HowToRaindance.md
+++ b/guides/HowToRaindance.md
@@ -4,15 +4,15 @@ This guide will walk you through the process.
 
 ## raindance
 
-![Raindance Channel](images/raindance/rain1.jpg)
+![Raindance Channel](../images/raindance/rain1.jpg)
 
 A raindance can happen when the TurtleBotRain wallet has accumulated 5,000 or more TRTL. It can also be triggered at-will by an admin.
 
-![Forecast](images/raindance/forecast.jpg)
+![Forecast](../images/raindance/forecast.jpg)
 
 When TurtleBotRain posts in the #raindance channel it means a Raindance is about to begin!
 
-![A Raindance is about to begin](images/raindance/tuttut.jpg)
+![A Raindance is about to begin](../images/raindance/tuttut.jpg)
 
 When you see this message the RainDance will begin soon.
 Get your TRTL wallet address ready.
@@ -21,34 +21,34 @@ Get your TRTL wallet address ready.
 
 Wait for the “Quick, send me your wallet” message.
 
-![Quick, send your wallet!](images/raindance/quick_rain.jpg)
+![Quick, send your wallet!](../images/raindance/quick_rain.jpg)
 
 Click on TurtleBotRain to send your address in a private message to TurtleBotRain.
 
-![Click on this](images/raindance/turtlebotrain.jpg)
+![Click on this](../images/raindance/turtlebotrain.jpg)
 
-![DM the bot](images/raindance/pm_bot.jpg)
+![DM the bot](../images/raindance/pm_bot.jpg)
 
 You should receive a private message back that looks like something like this:
 
-![You get a response](images/raindance/respo1.jpg)
+![You get a response](../images/raindance/respo1.jpg)
 
 or
 
-![You get a different resopnse](images/raindance/respo2.jpg)
+![You get a different resopnse](../images/raindance/respo2.jpg)
 
 **The Emoji will be different for everyone**
 
 Now return to the #raindance channel and react with the emoji you received in the private message.
 
-![React](images/raindance/react.jpg)
+![React](../images/raindance/react.jpg)
 
 Only click the emoji listed in the private message.
 
 If you did everything correctly you will be included in the payout! Congrats!
 TurtleBotRain will reply with the amount that you'll receive.
 
-![Payout!](images/raindance/payout.jpg)
+![Payout!](../images/raindance/payout.jpg)
 
 
 
@@ -57,7 +57,7 @@ TurtleBotRain will reply with the amount that you'll receive.
 
 ## !rain
 
-![Forecast](images/raindance/forecast.jpg)
+![Forecast](../images/raindance/forecast.jpg)
 
 If you type !rain **in the bots channel only** you should get a response back with how many turtles are needed for a raindance.
 
@@ -65,34 +65,34 @@ If you type !rain **in the bots channel only** you should get a response back wi
 ## Notify
 
 
-![Notification](images/raindance/notify.jpg)
+![Notification](../images/raindance/notify.jpg)
 
 
 Enabling notifications for the #raindance channel is easy.
 
 Click the dropdown arrow.
 
-![Dropdown](images/raindance/notify1.jpg)
+![Dropdown](../images/raindance/notify1.jpg)
 
 Click on notification settings.
 
-![Notification Settings](images/raindance/notify2.jpg)
+![Notification Settings](../images/raindance/notify2.jpg)
 
 Scroll down.
 
-![Scroll on down](images/raindance/notify3.jpg)
+![Scroll on down](../images/raindance/notify3.jpg)
 
 Look for notification overrides.
 
-![Notifcation Overrides](images/raindance/notify4.jpg)
+![Notifcation Overrides](../images/raindance/notify4.jpg)
 
 Select "raindance".
 
-![Select Raindance](images/raindance/notify5.jpg)
+![Select Raindance](../images/raindance/notify5.jpg)
 
 Select "All".
 
-![Select All](images/raindance/notify6.jpg)
+![Select All](../images/raindance/notify6.jpg)
 
 Done.
 

--- a/guides/HowToRaindance.md
+++ b/guides/HowToRaindance.md
@@ -6,11 +6,11 @@ This guide will walk you through the process.
 
 ![Raindance Channel](images/raindance/rain1.jpg)
 
-A raindance can happen when the TurtleBotRain wallet has acumulated 10,000 turtles.
+A raindance can happen when the TurtleBotRain wallet has accumulated 5,000 or more TRTL. It can also be triggered at-will by an admin.
 
 ![Forecast](images/raindance/forecast.jpg)
 
-When TurtleBotRain posts in the raindance channel it means a Raindance is about to begin!
+When TurtleBotRain posts in the #raindance channel it means a Raindance is about to begin!
 
 ![A Raindance is about to begin](images/raindance/tuttut.jpg)
 
@@ -23,13 +23,13 @@ Wait for the “Quick, send me your wallet” message.
 
 ![Quick, send your wallet!](images/raindance/quick_rain.jpg)
 
-Click on TurtleBotRain to send your address as a PM to TurtleBotRain.
+Click on TurtleBotRain to send your address in a private message to TurtleBotRain.
 
 ![Click on this](images/raindance/turtlebotrain.jpg)
 
 ![DM the bot](images/raindance/pm_bot.jpg)
 
-You should recieve a PM back that looks like something like this:
+You should receive a private message back that looks like something like this:
 
 ![You get a response](images/raindance/respo1.jpg)
 
@@ -39,13 +39,14 @@ or
 
 **The Emoji will be different for everyone**
 
-Now return to the raindance channel and react with the emoji you recieved in the PM.
+Now return to the #raindance channel and react with the emoji you received in the private message.
 
 ![React](images/raindance/react.jpg)
 
-Only click the emoji listed in the PM.
+Only click the emoji listed in the private message.
 
-If you did everything correct you are included in the payout! Congrats!
+If you did everything correctly you will be included in the payout! Congrats!
+TurtleBotRain will reply with the amount that you'll receive.
 
 ![Payout!](images/raindance/payout.jpg)
 
@@ -67,7 +68,7 @@ If you type !rain **in the bots channel only** you should get a response back wi
 ![Notification](images/raindance/notify.jpg)
 
 
-Enabling notifications for the raindance channel is easy.
+Enabling notifications for the #raindance channel is easy.
 
 Click the dropdown arrow.
 


### PR DESCRIPTION
Spelling and clarification updates + minimum TRTL amount corrected
Includes recent image path corrections per being moved into /guides as well

It's worth noting that there are two versions of How To Raindance in /guides:
03-how-to-raindance.md
HowToRaindance.md

It looks like the only differences are donation information in one and not the other.
Maybe consolidate into just one?
