### PR TITLE
Paper wallet cold storage

### DIFF
--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -24,6 +24,7 @@
     - [Saving the Wallet](Getting-Started#saving-the-wallet)
 
 - [[Frequently Asked Questions]]
+  - [Paper Wallet / Cold Storage?](Frequently-Asked-Questions#Paper-wallet-cold-storage)
 
 - Guides
   - Alternative Installation Methods

--- a/faq/Frequently-Asked-Questions.md
+++ b/faq/Frequently-Asked-Questions.md
@@ -233,6 +233,20 @@ Did this guide help you out? Throw some shells my way: `TRTLv2Fyavy8CXG8BPEbNeCH
   * walletd is importing blocks from the DB, which takes a while and so the GUI thinks it has crashed. Solution here - <https://github.com/turtlecoin/desktop-xamarin/issues/17#issuecomment-366790435>
   * If all else fails, if you have your private keys then you can instead import your wallet into simplewallet. 
 
+## Paper Wallet / Cold Storage?
+
+* **Q: Wait, What's Cold Storage?**
+
+    A: The term Cold Storage refers to a wallet that has been created via an offline means. The preferred way to do this is via a computer than has never ever been connected to the internet, commonly referred to as an air gapped device. Why is this a thing? If done properly it means it is near impossible for the keys to be secrectly intercepted since the data is never viewable by other compute devices. You see above/elsewhere wallet files are being created via the wallet software, these files might be stored unencyprted, If unencypted then the keys can be read by malicious software and balance's of those wallets transferred, Thus to protect against that scenario you could transfer any TRTL balance to one of these Cold Storage addresses. Please remember to keep secure/secret backups of your keys. If you lose the keys you lose any balance that was transferred to that wallet. You can use the paper wallet files below, to generate a Cold Storage address & keys. 
+    
+* **Q: Can I make a paper wallet?**
+
+    A: Yes, you can use the link here: <http://turtlecoin.lol/wallet> - If you want to run it locally on an offline computer for security, you can download the source code [here](https://github.com/turtlecoin/paper-turtle), and open the html file in your browser.
+
+* **Q: Can I view the balance of my wallet online?**
+
+    A: Due to turtlecoin being a privacy coin, this is not possible. It should be possible in the future to allow users to give away just their view private key to view transactions, but this hasn't been implemented by anyone so far, and would allow that website to see every transaction that you make.
+
 ## Other
 
 * **Q: Why does TRTL have such a high amount of tokens/small amount of decimal places?**
@@ -268,14 +282,6 @@ Did this guide help you out? Throw some shells my way: `TRTLv2Fyavy8CXG8BPEbNeCH
 * **Q: Is there a blockchain explorer?**
 
     A: Yes, there are two: <https://blocks.turtle.link/> and <https://turtle-coin.com/>
-
-* **Q: Can I make a paper wallet?**
-
-    A: Yes, you can use the link here: <http://turtlecoin.lol/wallet> - If you want to run it locally on an offline computer for security, you can download the source code [here](https://github.com/turtlecoin/paper-turtle), and open the html file in your browser.
-
-* **Q: Can I view the balance of my wallet online?**
-
-    A: Due to turtlecoin being a privacy coin, this is not possible. It should be possible in the future to allow users to give away just their view private key to view transactions, but this hasn't been implemented by anyone so far, and would allow that website to see every transaction that you make.
 
 * **Q: I have a question which wasn't answered here, what should I do?**
 


### PR DESCRIPTION
To enable linking from the sidebar under FAQ created a separate section.
Why? Cause looking at the wiki ans scanning for paper wallet it is not obvious
where one should look.
This speeds up zerooing on the required link as it is not exposed anywhere else
publicly yet.